### PR TITLE
circumventing a system-wide Jupyterhub

### DIFF
--- a/personalizing_conda_on_gyre_sverdrup.md
+++ b/personalizing_conda_on_gyre_sverdrup.md
@@ -1,20 +1,20 @@
 # Gyre Conda Environments
 
-You can access gyre after going through the [LDEO vpn](https://ldeo-it.ldeo.columbia.edu/content/vpn-virtual-private-network), and then 
+You can access gyre after going through the [LDEO vpn](https://ldeo-it.ldeo.columbia.edu/content/vpn-virtual-private-network), and then
 accessing via terminal:
 ```ssh -x <username>@gyre.ldeo.columbia.edu```
  or accessing the jupyter lab server directly:
- ```https://gyre.ldeo.columbia.edu/```. 
+ ```https://gyre.ldeo.columbia.edu/```.
 
-This will bring you to a place where you have access to the a system wide python (`/usr/local/anaconda/bin/python`) and conda (`/usr/local/anaconda/bin/conda`), to install modules. 
+This will bring you to a place where you have access to the a system wide python (`/usr/local/anaconda/bin/python`) and conda (`/usr/local/anaconda/bin/conda`), to install modules.
 
-However, often when using gyre or sverdrup, the user will want to install python modules of their own choice and manage their own environments for their projects. 
+However, often when using gyre or sverdrup, the user will want to install python modules of their own choice and manage their own environments for their projects.
 
 **Step by step to create your own environment**:
-1. Create conda environment at command line 
-`conda env create -f environment.yml` 
-where the `environment.yml` file is user defined, an example that works on gyre is shown below. It is ok if you don't get all your requirements at this point, you can install them later using `conda install <package_name> -c conda-forge` or `pip install <package_name>` or directly by getting the binaries from github or other location. 
-This step should run successfully and when it finishes give you instructions on how to activate and deactivate this conda environment. And this is all that you need to do. The environment will show up as an option on your jupyter lab called `Python [Conda env:user_env]` to open a new notebook or terminal in. 
+1. Create conda environment at command line
+`conda env create -f environment.yml`
+where the `environment.yml` file is user defined, an example that works on gyre is shown below. It is ok if you don't get all your requirements at this point, you can install them later using `conda install <package_name> -c conda-forge` or `pip install <package_name>` or directly by getting the binaries from github or other location.
+This step should run successfully and when it finishes give you instructions on how to activate and deactivate this conda environment. And this is all that you need to do. The environment will show up as an option on your jupyter lab called `Python [Conda env:user_env]` to open a new notebook or terminal in.
 
 Example `envrionment.yml` file:
 ```
@@ -76,21 +76,30 @@ dependencies:
   - xmitgcm
 ```
 
-2. You can activate your environment by `conda activate users_env`. You will need to do this before you can install anything else in your own environment. 
+2. You can activate your environment by `conda activate users_env`. You will need to do this before you can install anything else in your own environment.
 
 This is all you need to do. Now you can open notebooks that have access to this environment, as discussed next.
 
 **Opening a notebook with your environment**
-After you have created your own environment, you should be able to access it as kernel in your jupyter lab. It will show up on your launcher: 
+After you have created your own environment, you should be able to access it as kernel in your jupyter lab. It will show up on your launcher:
 ![](https://i.imgur.com/v64ppy2.png)
 
+In the case conficts emerge with your local and system conda, you can launch Jupyterlab via ssh tunneling. (I no longer have access to Gyre so if someone could check if the following procedures work on it, that's be swell!!)
+
+ - Install miniconda
+ - Activate your local miniconda via `source .bashrc`
+ - Create your conda environment and activate it (`conda activate users_env`)
+ - Boot up Jupyter lab without a browser: `jupyter lab --no-browser`. (You should get a message that the lab is running at `localhost:XXXX` where XXXX will be the port address)
+ - Now open a new Terminal window and ssh to that port using: `ssh -A -t -l <username>@gyre.ldeo.columbia.edu  -L YYYY:localhost:XXXX`. YYYY can be any available port on your local laptop.
+ - Open your browser and go to `localhost:YYYY`. Et voila, you have a working Jupyterlab.
+
 **Deleting Old Environments**
-You can delete you old environment by following: 
-1. 
+You can delete you old environment by following:
+1.
 
 
 ## FAQs
-- I am having trouble with opening and running notebooks, because I believe I have had my jupyter lab instance open for too long, and errors have cropped up. Can I restart it? 
+- I am having trouble with opening and running notebooks, because I believe I have had my jupyter lab instance open for too long, and errors have cropped up. Can I restart it?
     - Yes you can. You will need to go to the `Commands` tab on the left of the jupyter lab, then open `Launch Classic Notebook`. This will open a new window, where you should see a button that says `Control Panel` on the left. You can click it, followed by clicking `Stop My Server`. Now if you logout and login again, you will be on a fresh jupyter lab instance which will be working with the latest libraries on gyre in a fresh instance.
-- How can I look at the resource usage on Gyre? 
+- How can I look at the resource usage on Gyre?
     - You can get an overview of resource usage using the netdata dashboard that can be accessed at: http://gyre.ldeo.columbia.edu:19999/


### PR DESCRIPTION
I've been using this procedure to set up Jupyterlab when either there's no conda installed onto the remote machine or when I want to circumvent the system-wide conda. Hope it works on Gyre too!